### PR TITLE
finish v0.2.0

### DIFF
--- a/phase2/endpoint.cpp
+++ b/phase2/endpoint.cpp
@@ -1,5 +1,9 @@
+#define _CRT_SECURE_NO_WARNINGS // ignore strcpy errors
+
 #include "endpoint.h"
 #include <iostream>
+// #include <mstcpip.h> // for socket keep_alive
+#include "mystringfunc.h"
 
 using namespace std;
 
@@ -11,15 +15,28 @@ Endpoint::Endpoint(int _playerID, sqlite3 *&_db) : db(_db), playerID(_playerID)
 
 Endpoint::~Endpoint()
 {
+	running = false;
+	while (timing)
+	{
+		// cout << "Try to stop timer.\n";
+		unique_lock<mutex> lock(mtx);
+		online = true;
+		lock.unlock();
+		cv.notify_one();
+		lock.lock();
+	}
+
 	closesocket(endpointSocket);
+
 	if (port)
-		cout << "\nEndpoint[" << playerID << "] stoped at " << port << ".\n";
+		cout << "Endpoint[" << playerID << "]: Endpoint stoped at " << port << endl;
 }
 
 int Endpoint::start()
 {
 	/**
 	 * init endpoint socket
+	 * 
 	 * function: socket(int domain, int type, int protocol);
 	 * domain: AF_INET or PF_INET
 	 *   - AF for Address Family
@@ -34,7 +51,7 @@ int Endpoint::start()
 	{
 		cout << "Endpoint[" << playerID << "]: Init socket failed.\n";
 		closesocket(endpointSocket);
-		system("pause");
+		// system("pause");
 		return 0;
 	}
 	// cout << "Done.\n";
@@ -45,13 +62,61 @@ int Endpoint::start()
 	endpointAddr.sin_port = htons(0);											 // port = 0 so windows will give us a free port
 	endpointAddr.sin_addr.S_un.S_addr = htonl(INADDR_ANY); // any ip address
 
+#pragma region set socket keep_alive
+/**
+ * I spend hours for the 40 lines of code below
+ * And when I finish this module
+ * I try to run without this block of code
+ * IT STILL WORKS!
+ * DAMN!
+*/
+
+// 	int iOptVal = 0;
+// 	int iOptLen = sizeof(int);
+// 	BOOL bOptVal = FALSE;
+// 	int bOptLen = sizeof(BOOL);
+// 	if (getsockopt(endpointSocket, SOL_SOCKET, SO_KEEPALIVE, (char *)&iOptVal, &iOptLen) == SOCKET_ERROR)
+// 	{
+// 		cout << "Endpoint[" << playerID << "]: Set keep_alive failed: " << WSAGetLastError() << "\n";
+// 		closesocket(endpointSocket);
+// 		return 0;
+// 	}
+// 	if (setsockopt(endpointSocket, SOL_SOCKET, SO_KEEPALIVE, (char *)&bOptVal, bOptLen) == SOCKET_ERROR)
+// 	{
+// 		cout << "Endpoint[" << playerID << "]: Set keep_alive failed: " << WSAGetLastError() << "\n";
+// 		closesocket(endpointSocket);
+// 		return 0;
+// 	}
+// 	/**
+// 	 * set KeepAlive parameter
+// 	 *
+// 	 * struct tcp_keepalive{
+// 	 *   ULONG onoff; // TRUE or FALSE
+// 	 *   ULONG keepalivetime; // after this time(ms) without data, send heart-beat
+// 	 *   ULONG keepaliveinterval; // heart-beat interval(ms)
+// 	 * };
+// 	 */
+// 	tcp_keepalive alive_in;
+// 	tcp_keepalive alive_out;
+// 	alive_in.keepalivetime = 500;			 // 0.5s
+// 	alive_in.keepaliveinterval = 1000; //1s
+// 	alive_in.onoff = TRUE;						 // turn on keep_alive
+// 	unsigned long ulBytesReturn = 0;
+// 	if (WSAIoctl(endpointSocket, SIO_KEEPALIVE_VALS, &alive_in, sizeof(alive_in), &alive_out, sizeof(alive_out), &ulBytesReturn, NULL, NULL) == SOCKET_ERROR)
+// 	{
+// 		cout << "Endpoint[" << playerID << "]: Set keep_alive failed: " << WSAGetLastError() << "\n";
+// 		closesocket(endpointSocket);
+// 		return 0;
+// 	}
+#pragma endregion
+
 	// bind socket to an address
 	// cout << "Endpoint[" << playerID << "]: Socket binding...";
 	if (::bind(endpointSocket, (sockaddr *)&endpointAddr, sizeof(endpointAddr)) == SOCKET_ERROR)
 	{
 		cout << "Endpoint[" << playerID << "]: Socket bind failed.\n";
 		closesocket(endpointSocket);
-		system("pause");
+		// system("pause");
 		return 0;
 	}
 	// cout << "Done.\n";
@@ -68,63 +133,120 @@ int Endpoint::start()
 		cout << WSAGetLastError();
 		cout << "Endpoint[" << playerID << "]: Socket listen failed.\n";
 		closesocket(endpointSocket);
-		system("pause");
+		// system("pause");
 		return 0;
 	}
 	// cout << "Done.\n";
 
 	// now listen successfully
-	cout << "\nEndpoint[" << playerID << "]: Endpoint is running at " << port << "\n\n";
+	cout << "Endpoint[" << playerID << "]: Endpoint is running at " << port << "\n";
 
-	running = true;
+	running = true; // enable Endpoint::process()
 
 	return port;
 }
 
 void Endpoint::process()
 {
-	thread listenThread(&Endpoint::listenFunc, this);
-	thread timerThread(&Endpoint::timer, this);
-	listenThread.join();
-	timerThread.join();
+	while (running)
+	{
+		online = false;
+		timing = true;
+
+		thread timerThread(&Endpoint::timer, this);
+		thread listenThread(&Endpoint::listenFunc, this);
+		timerThread.join();
+		listenThread.join();
+	}
 }
 
 void Endpoint::listenFunc()
 {
-	// while (running){
-	// 	// link
-	// 	sockaddr_in clientAddr; // client address
-	// 	int clientAddrLength = sizeof(clientAddr);
-	// 	connSocket = accept(serverSocket, (sockaddr *)&clientAddr, &clientAddrLength);
-	// 	if (connSocket == INVALID_SOCKET)
-	// 	{
-	// 		if (running)
-	// 		{
-	// 			// if not running, this thread must be terminated by terminateFunc
-	// 			// in that case the string below is not needed
-	// 		}
-	// 		closesocket(connSocket);
-	// 		continue;
-	// 	}
+	// link
+	sockaddr_in clientAddr; // client address
+	int clientAddrLength = sizeof(clientAddr);
+	connSocket = accept(endpointSocket, (sockaddr *)&clientAddr, &clientAddrLength);
+	while (timing)
+	{
+		// cout << "Try to stop timer.\n";
+		unique_lock<mutex> lock(mtx);
+		online = true;
+		lock.unlock();
+		cv.notify_one();
+		lock.lock();
+	}
+	if (connSocket == INVALID_SOCKET)
+	{
+		// TODO
+		return;
+	}
 
-	// 	// link successfully
-
-	// }
+	// link successfully
+	char buf[BUF_LENGTH] = "";
+	int ret = recv(connSocket, buf, BUF_LENGTH, 0);
+	/**
+	 * recv(connSocket, buf, BUF_LENGTH, 0)
+	 * - return bytes of buf
+	 * - return 0 if client socket closed or get an empty line
+	 * - return SOCKET_ERROR(-1) if server socket is closed or client unexpectedly terminated
+	*/
+	while (ret != 0 && ret != SOCKET_ERROR && running) // normal
+	{
+		// parse command here
+		// TODO
+		auto strs = split(buf);
+		if (strs[0] == "logout")
+		{
+			running = false;
+		}
+		else
+		{
+			cout << "Endpoint[" << playerID << "]: Invalid request.\n";
+			strcpy(buf, "Reject: Invalid request.\n");
+			send(connSocket, buf, BUF_LENGTH, 0);
+		}
+		if (running)
+			ret = recv(connSocket, buf, BUF_LENGTH, 0);
+	}
+	if (ret == SOCKET_ERROR || ret == 0)
+	{
+		cout << "Endpoint[" << playerID << "]: Client unexpected offline, start timing.\n";
+	}
+	else
+	{
+		// running == false, user logout
+		cout << "Endpoint[" << playerID << "]: User logout.\n";
+	}
+	closesocket(connSocket);
 }
 
 void Endpoint::timer()
 {
 	using namespace std::chrono_literals;
 
-	while (running)
+	// cout << "Start timing.\n";
+
+	/**
+	 * wait for player re-login for 10 minutes
+	 * 
+	 * condition_variable::wait_for(lock, time, condition);
+	 * - lock is for variables in this function
+	 *   - now lock is for bool running
+	 * - return false when time out and condition == false
+	 * - return true when otherwise
+	*/
+	unique_lock<mutex> lock(mtx);
+	if (!cv.wait_for(lock, 10m, [this] { return online; }))
 	{
-		// sleep for 5 minutes
-		this_thread::sleep_for(50s);
-
-		// judge socket state
-		// TODO
+		// player is offline
 		running = false;
+		timing = false;
+		closesocket(endpointSocket);
+		// cout << "Time up.\n";
 	}
-
-	closesocket(endpointSocket);
+	else
+	{
+		timing = false;
+		// cout << "Stop timing.\n";
+	}
 }

--- a/phase2/endpoint.h
+++ b/phase2/endpoint.h
@@ -4,6 +4,7 @@
 #include <thread>
 #include <mutex>
 #include <string>
+#include <condition_variable>
 
 // about socket
 #include <WinSock2.h>
@@ -25,13 +26,16 @@ class Endpoint
 	string ip;
 	SOCKET endpointSocket;
 	SOCKET connSocket;
-	bool running;
+	volatile bool running;
+	volatile bool online;
 
 	// about player
 	int playerID;
 
 	// about thread
 	mutex mtx;
+	condition_variable cv;
+	volatile bool timing; // thread function timer is running
 
 	// thread function
 	void timer();
@@ -43,4 +47,6 @@ public:
 
 	int start();		// return port, return 0 if ERROR
 	void process(); // return to delete this endpoint
+
+	bool isOnline() const { return online; }
 };

--- a/phase2/mystringfunc.cpp
+++ b/phase2/mystringfunc.cpp
@@ -18,7 +18,6 @@ vector<string> split(const string &str, char ch)
 			t = "";
 		}
 	}
-	if (str.length())
-		result.push_back(t);
+	result.push_back(t);
 	return result;
 }

--- a/phase2/server.h
+++ b/phase2/server.h
@@ -28,7 +28,7 @@ private:
 	// about network
 	SOCKET serverSocket;
 	SOCKET connSocket;
-	bool running;
+	volatile bool running;
 	char buf[BUF_LENGTH];
 
 	//about database
@@ -38,7 +38,7 @@ private:
 	vector<Endpoint *> endpoints;
 
 	// about thread
-	mutex mtx;
+	mutex mtx; // to protect endpoints
 
 	// interfaces
 	void login(const string &username, const string &password);


### PR DESCRIPTION
- thread protection
  - set volatile
    - Server::runnning
    - Endpoint::runnning
    - Endpoint::online
    - Endpoint::timing
  - use lock and mutex in class Server and Endpoint
- Server.cpp
  - fix ~Server(), delete endpoints safely with mutex
  - disable some system("pause") and update output&comment
  - fix start(), delele endpoints safely
  - fix login(), identify username and password dismatch
  - update login(), better and safer operations about endpoitns
  - fix mornitor(), delete endpoint safely
- fix mystringfunc.h::split, always return at least one string
- endpoint.h&cpp
  - use condition_variable for timer()
  - update ~Endpoint(), stop timer safely
  - disable some system("pause"), better output&comments
  - update process(), using a loop
  - finish listenFunc,
    - client can logout safely
    - server can detect unexpected offline and start timer
  - fix and finish timer()
    - use condition_variable::wait_for instead of thread::sleep_for
- update README.md
- TODO
  - deal with re-login in Server
  - add process functions in Endpoint